### PR TITLE
Fix Rating Persistence

### DIFF
--- a/client/index.html
+++ b/client/index.html
@@ -9,7 +9,7 @@
   <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/5.15.3/css/all.min.css" integrity="sha384-KyZXEAg3QhqLMpG8r+8fhAXLRk2vvoC2f9q0Bd2JMD7ViT4Pv+aL3z5m3JvFKy0x" crossorigin="anonymous">
   <link href="https://fonts.googleapis.com/css2?family=Roboto:wght@400;700&display=swap" rel="stylesheet">
 
-  <title>Vite + React</title>
+  <title>W.A.K</title>
 </head>
 <body>
 <div id="root"></div>

--- a/client/src/Context/AuthContext.jsx
+++ b/client/src/Context/AuthContext.jsx
@@ -26,8 +26,6 @@ export const AuthContextProvider = ({children}) => {
         }
     }, [])
 
-    console.log('AuthContext state:', state)
-
     return (
         <AuthContext.Provider value={{...state, dispatch}}>
             {children}

--- a/client/src/Pages/Details/index.jsx
+++ b/client/src/Pages/Details/index.jsx
@@ -18,47 +18,34 @@ const MovieDetailsPage = () => {
     const [userRating, setUserRating] = useState(null);
 
     async function findRating(userRatingsData, title) {
-        const details = await userRatingsData;
-        console.log(details);
-        console.log(title);
-        const {movies} = details;
-
+        const {movies} = await userRatingsData;
+        // Find movie with matching Title
+        // TODO: Introduce Movie Id variable to avoid identical ratings of movies with Identical names
         const movie = movies.find((x) => x.movieTitle == title);
-        
-        console.log(movie);
 
-        if (!movie) {
-            return null;
+        if (movie) {
+            return movie.rating;
         }
-        
-        console.log("About to return");
-        console.log(movie.rating);
 
-        return movie.rating;
+        return null;
     }
   
     useEffect(() => {
-
         async function processRating () {
+            // We need the movie Title and the users Username in order to identify the rating for a given movie
+            // We also do not want to contiually run this function everytime the user rating changes
+            // TODO: Memoize this response
             if (movieData && userRating == null && user) {
            
-            // Fetch the movie rating for the logged-in user
-    
-            const resp = fetch(`${import.meta.env.VITE_BASE_API_URL}/api/${user.username}/rating/movie/${encodeURIComponent(movieId)}`, {
+            // Fetch list of movie ratings for a given user
+            const userRatingsData = fetch(`${import.meta.env.VITE_BASE_API_URL}/api/${user.username}/ratings`, {
                 method: 'GET',
             })
                 .then(response => response.json())
-                
                 .catch(error => {
                     console.error('Error fetching movie rating:', error);
                 });
-    
-                const val = await findRating(resp, movieData.title);
-                console.log(val);
-                setUserRating(val);
-                console.log("User rating");
-                console.log(userRating);
-    
+                setUserRating(await findRating(userRatingsData, movieData.title));
             }
         }
 

--- a/client/src/Pages/Details/index.jsx
+++ b/client/src/Pages/Details/index.jsx
@@ -13,21 +13,58 @@ const MovieDetailsPage = () => {
     const {id} = useParams();
     const urlParts = id.split('/');
     const movieId = urlParts[urlParts.length - 1];
-    const {user} = useAuthContext()
-    const {rating} = useRating()
+    const {user} = useAuthContext();
+    const {rating} = useRating();
     const [userRating, setUserRating] = useState(null);
 
+    async function findRating(userRatingsData, title) {
+        const details = await userRatingsData;
+        console.log(details);
+        console.log(title);
+        const {movies} = details;
+
+        const movie = movies.find((x) => x.movieTitle == title);
+        
+        console.log(movie);
+
+        if (!movie) {
+            return null;
+        }
+        
+        console.log("About to return");
+        console.log(movie.rating);
+
+        return movie.rating;
+    }
+  
     useEffect(() => {
-        // Fetch the movie rating for the logged-in user
-        fetch(`/api/rating/movie/${encodeURIComponent(movieId)}`)
-            .then(response => response.json())
-            .then(data => {
-                setUserRating(data.rating);
+
+        async function processRating () {
+            if (movieData && userRating == null && user) {
+           
+            // Fetch the movie rating for the logged-in user
+    
+            const resp = fetch(`${import.meta.env.VITE_BASE_API_URL}/api/${user.username}/rating/movie/${encodeURIComponent(movieId)}`, {
+                method: 'GET',
             })
-            .catch(error => {
-                console.error('Error fetching movie rating:', error);
-            });
-    }, [movieId]);
+                .then(response => response.json())
+                
+                .catch(error => {
+                    console.error('Error fetching movie rating:', error);
+                });
+    
+                const val = await findRating(resp, movieData.title);
+                console.log(val);
+                setUserRating(val);
+                console.log("User rating");
+                console.log(userRating);
+    
+            }
+        }
+
+        processRating();
+        
+    }, [movieId, user, movieData, userRating]);
 
 
 

--- a/client/src/Pages/Home/index.jsx
+++ b/client/src/Pages/Home/index.jsx
@@ -21,7 +21,6 @@ const Home = () => {
                     );
                     if (response.status === 200) {
                         movies.push(...response.data.results);
-                        console.log('movies', movies);
                     } else {
                         console.error('Request failed with status:', response.status);
                     }

--- a/server/index.js
+++ b/server/index.js
@@ -56,9 +56,7 @@ app.post('/signup', async (req, res) => {
 
 app.post('/rating', async (req, res) => {
     const {username, rating, movie} = req.body
-
     try{
-        console.log("WAITIN")
         await Rating.review(username, movie, rating);
         res.status(200).json({username, movie, rating})
     }
@@ -67,32 +65,12 @@ app.post('/rating', async (req, res) => {
     }
 });
 
-
-app.get('/api/:username/rating/movie/:movieId', async (req, res) => {
-    console.log("in here");
-    // res.json("test");
-    const { username, movieId } = req.params;
-    // const username = req.body.username; // Assuming you have user authentication middleware
-    
-    // res.json(username);
-     
- try {
+app.get('/api/:username/ratings', async (req, res) => {
+    const { username } = req.params;
+    try {
         const existingUserRating = await Rating.findOne({ username });
-        
         if (existingUserRating) {
-            res.json(existingUserRating);
-
-            /**
-            
-            const movieRating = existingUserRating.movies.find(item => item.movieId === movieId);
-            if (movieRating) {
-                res.json({ rating: movieRating.rating });
-            } else {
-                res.json({ rating: null }); // Movie not rated by the user
-            }
-
-             */
-            
+            res.json(existingUserRating);            
         } else {
             res.json({ rating: null }); // User has not rated any movies
         }
@@ -103,10 +81,9 @@ app.get('/api/:username/rating/movie/:movieId', async (req, res) => {
    
 });
 
-
 mongoose.connect(process.env.MONGO_URI)
     .then(() => {
-        app.listen(process.env.PORT, () => console.log(`Server IS running` + process.env.PORT));
+        app.listen(process.env.PORT, () => console.log(`Server is running on port: ` + process.env.PORT));
     })
     .catch(err => {
         console.log(err);

--- a/server/index.js
+++ b/server/index.js
@@ -67,19 +67,32 @@ app.post('/rating', async (req, res) => {
     }
 });
 
-app.get('/api/rating/movie/:movieId', async (req, res) => {
-    const { movieId } = req.params;
-    const username = req.user.username; // Assuming you have user authentication middleware
 
-    try {
+app.get('/api/:username/rating/movie/:movieId', async (req, res) => {
+    console.log("in here");
+    // res.json("test");
+    const { username, movieId } = req.params;
+    // const username = req.body.username; // Assuming you have user authentication middleware
+    
+    // res.json(username);
+     
+ try {
         const existingUserRating = await Rating.findOne({ username });
+        
         if (existingUserRating) {
+            res.json(existingUserRating);
+
+            /**
+            
             const movieRating = existingUserRating.movies.find(item => item.movieId === movieId);
             if (movieRating) {
                 res.json({ rating: movieRating.rating });
             } else {
                 res.json({ rating: null }); // Movie not rated by the user
             }
+
+             */
+            
         } else {
             res.json({ rating: null }); // User has not rated any movies
         }
@@ -87,6 +100,7 @@ app.get('/api/rating/movie/:movieId', async (req, res) => {
         console.error('Error fetching movie rating:', error);
         res.status(500).json({ error: 'Internal server error' });
     }
+   
 });
 
 


### PR DESCRIPTION
Fixes Rating Save Functionality allowing user's ratings of movies to be successfully retrieved from the database.

Note: Due to the way the Ratings are stored currently, It is only possible to retrieve them by title. This means that a rating for a movie with title "x" may also display identically for a different movie with the same title ("x").

Closes #54 