### PR TITLE
fix/ invalid login credentials handling

### DIFF
--- a/client/src/Hooks/useLogin.js
+++ b/client/src/Hooks/useLogin.js
@@ -19,34 +19,31 @@ export const useLogin = () => {
         setError(null);
 
         // Sending a POST request to the login endpoint with the username and password
-        const response = await fetch(
-            `${import.meta.env.VITE_BASE_API_URL}/login`,
-            {
-                method: "POST",
-                headers: { "Content-Type": "application/json" },
-                body: JSON.stringify({ username, password }),
+        try {
+            const response = await fetch(
+                `${import.meta.env.VITE_BASE_API_URL}/login`,
+                {
+                    method: "POST",
+                    headers: { "Content-Type": "application/json" },
+                    body: JSON.stringify({ username, password }),
+                }
+            );
+
+            const json = await response.json();
+
+            if (!response.ok) {
+                setError(
+                    json.message ||
+                        "Incorrect username or password, please try again"
+                );
+                return;
             }
-        );
 
-        // Parsing the response to JSON
-        const json = await response.json();
-
-        // Checking the response status
-        if (!response.ok) {
-            // If response is not OK, storing user data to localStorage
-            // and dispatching LOGIN action with received user data
             localStorage.setItem("user", JSON.stringify(json));
             dispatch({ type: "LOGIN", payload: json });
-            // Setting loading state to false
-            setIsLoading(false);
-        }
-
-        if (response.ok) {
-            // If response is OK, storing user data to localStorage
-            // and dispatching LOGIN action with received user data
-            localStorage.setItem("user", JSON.stringify(json));
-            dispatch({ type: "LOGIN", payload: json });
-            // Setting loading state to false
+        } catch (error) {
+            setError("Unexpected error occurred. Please try again.");
+        } finally {
             setIsLoading(false);
         }
     };

--- a/client/src/Pages/Login/index.jsx
+++ b/client/src/Pages/Login/index.jsx
@@ -2,43 +2,63 @@ import { useState } from "react";
 import { useLogin } from "../../Hooks/useLogin.js";
 import "./style.css";
 
-import backgroundImage from "./img/movies.jpeg"; 
+import backgroundImage from "./img/movies.jpeg";
 
 const Index = () => {
-    const [username, setUserName] = useState('');
-    const [password, setPassword] = useState('');
+    const [username, setUserName] = useState("");
+    const [password, setPassword] = useState("");
+    const [validationError, setValidationError] = useState("");
     const { login, error, isLoading } = useLogin();
 
     const handleSubmit = async (e) => {
         e.preventDefault();
+        // Check if username or password fields are empty and set validation error if true
+        if (username.trim() === "" || password.trim() === "") {
+            setValidationError("Please enter your credentials to login");
+            return;
+        } else {
+            setValidationError("");
+        }
         await login(username, password);
     };
 
     return (
         <div className="home-container-login">
-        <div className="background-image-login" style={{ backgroundImage: `url(${backgroundImage})`, backgroundSize: "cover", backgroundRepeat: "no-repeat" }}></div>
-        <div className="overlay-login"></div>  
-        <div className="login-page">
-            <form className="login" onSubmit={handleSubmit}>
-                <h3>Log In</h3>
+            <div
+                className="background-image-login"
+                style={{
+                    backgroundImage: `url(${backgroundImage})`,
+                    backgroundSize: "cover",
+                    backgroundRepeat: "no-repeat",
+                }}
+            ></div>
+            <div className="overlay-login"></div>
+            <div className="login-page">
+                <form className="login" onSubmit={handleSubmit}>
+                    <h3>Log In</h3>
 
-                <label>Username:</label>
-                <input
-                    type="text"
-                    onChange={(e) => setUserName(e.target.value)}
-                    value={username}
-                />
-                <label>Password:</label>
-                <input
-                    type="password"
-                    onChange={(e) => setPassword(e.target.value)}
-                    value={password}
-                />
+                    <label>Username:</label>
+                    <input
+                        type="text"
+                        onChange={(e) => setUserName(e.target.value)}
+                        value={username}
+                    />
+                    <label>Password:</label>
+                    <input
+                        type="password"
+                        onChange={(e) => setPassword(e.target.value)}
+                        value={password}
+                    />
 
-                <button className="login-button" disabled={isLoading}>Log in</button>
-                {error && <div className="error">{error}</div>}
-            </form>
-        </div>
+                    <button className="login-button" disabled={isLoading}>
+                        Log in
+                    </button>
+                    {validationError && (
+                        <div className="error">{validationError}</div>
+                    )}
+                    {error && <div className="error">{error}</div>}
+                </form>
+            </div>
         </div>
     );
 };


### PR DESCRIPTION
This PR addresses the issue outlined in (#65), which allowed users to log in without valid credentials. The following enhancements have been made to address this:
- Implemented input validation on the login form to ensure that both username and password fields are filled before attempting a login.
- Corrected the response handling in the useLogin hook. The previous implementation executed success operations even when the server returned an error status. This has been amended to appropriately to set an error message, signalling a failed login when the server response is not OK.

Screenshots:

Input validation:
![image](https://github.com/SE310-1/W.A.K/assets/100451063/d8771618-d990-4159-a5a8-64f5c0c5c2cb)

![image](https://github.com/SE310-1/W.A.K/assets/100451063/6c60e2b8-040d-4197-91b4-043aebcd722f)

Appropriate user-feedback during incorrect credentials:
![image](https://github.com/SE310-1/W.A.K/assets/100451063/94ee921f-7b60-4557-8ebc-ebc2fc25ad18)




