### PR TITLE
Removing Facebook sign-in

### DIFF
--- a/client/src/Pages/Login/index.jsx
+++ b/client/src/Pages/Login/index.jsx
@@ -58,20 +58,6 @@ const Index = () => {
           </button>
           {validationError && <div className="error">{validationError}</div>}
           {error && <div className="error">{error}</div>}
-
-          <LoginSocialFacebook
-            appId="1030308514679380" 
-            
-            onResolve= {(response) => {
-              console.log(response);
-            }}
-            onReject= {(error) => {
-              console.log(error);
-            }}
-
-            >
-            <FacebookLoginButton />
-          </LoginSocialFacebook>
         </form>
       </div>
     </div>

--- a/client/src/Pages/Signup/index.jsx
+++ b/client/src/Pages/Signup/index.jsx
@@ -57,12 +57,6 @@ const Index = () => {
           </button>
           {error && <div className="error">{error}</div>}
         </form>
-
-        <LoginSocialFacebook>
-        <FacebookLoginButton />
-      </LoginSocialFacebook>
-
-
       </div>
     </div>
   );


### PR DESCRIPTION
This PR looks to close issue #94. It removes the Facebook sign-in button from both the sign-in page as well as the signup page. The group collectively made the decision to postpone the implementation of signing in with Facebook to a later release, so this will effectively close that issue for the upcoming release.

Attached below is the state of the sign-in page after the Facebook sign in button was removed.

![image](https://github.com/SE310-1/W.A.K/assets/100258989/515027e7-f467-4ef4-83b3-70205a401457)
