### PR TITLE
Implement Google Authentication Client Side Logic

### DIFF
--- a/client/src/Hooks/useGoogleAuth.ts
+++ b/client/src/Hooks/useGoogleAuth.ts
@@ -1,0 +1,54 @@
+import { useState } from "react";
+import { useAuthContext } from "./useAuthContext";
+import { CredentialResponse } from "@react-oauth/google";
+
+// Defining a custom hook for handling Google Auth JWTs on the client side and passing them to the server
+export const useGoogleAuth = () => {
+  // Initializing state for error and loading indicators
+  const [googleAuthError, setGoogleAuthError] = useState("");
+  const [googleAuthIsLoading, setGoogleAuthIsLoading] = useState(true);
+
+  // Destructuring dispatch from the context to dispatch actions
+  const { dispatch } = useAuthContext();
+
+  // Defining the login function which takes a Google Auth credential response
+  const loginWithGoogleJWT = async (credentialResponse: CredentialResponse) => {
+    // Setting the loading state to true when login starts
+    setGoogleAuthIsLoading(true);
+    // Resetting any previous errors
+    setGoogleAuthError("");
+
+    // Sending a POST request to the login endpoint with the username and password
+    try {
+      const response = await fetch(
+        `${import.meta.env.VITE_BASE_API_URL}/login_google`,
+        {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ googleJWT: credentialResponse.credential }),
+        }
+      );
+
+      // Parse the JSON response
+      const json = await response.json();
+
+      if (!response.ok) {
+        setGoogleAuthError(
+          json.message || "Failed to authenticate with Google"
+        );
+        return;
+      }
+
+      // Log the user in and persist the JWT
+      localStorage.setItem("user", JSON.stringify(json));
+      dispatch({ type: "LOGIN", payload: json });
+    } catch (error) {
+      setGoogleAuthError("Unexpected error occurred. Please try again.");
+    } finally {
+      setGoogleAuthIsLoading(false);
+    }
+  };
+
+  // Returning login function along with loading and error states
+  return { loginWithGoogleJWT, googleAuthIsLoading, googleAuthError };
+};

--- a/client/src/Pages/Login/index.jsx
+++ b/client/src/Pages/Login/index.jsx
@@ -1,6 +1,7 @@
 import { useState } from "react";
 import React from "react";
 import { useLogin } from "../../Hooks/useLogin.js";
+import { loginWithGoogleJWT } from "../../Hooks/useGoogleAuth.js";
 import { GOOGLE_CLIENT_ID } from "../../../env.js";
 import { GoogleLogin, GoogleOAuthProvider } from '@react-oauth/google';
 import "./style.css";
@@ -27,12 +28,13 @@ const Index = () => {
 
   // Pass the Google JWT to the server to sign the user in
   const handleGoogleSignInSuccess = async (credentialResponse) => {
-    console.log(credentialResponse);
+    await loginWithGoogleJWT(credentialResponse);
   };
 
   // Display Google sign in errors to the user
   const handleGoogleSignInError = (error) => {
     console.log(error);
+    alert("Sorry there was an issue signing in with Google. Please try again.");
   };
 
   return (

--- a/client/src/Pages/Login/index.jsx
+++ b/client/src/Pages/Login/index.jsx
@@ -1,10 +1,9 @@
 import { useState } from "react";
+import React from "react";
 import { useLogin } from "../../Hooks/useLogin.js";
 import { GOOGLE_CLIENT_ID } from "../../../env.js";
 import { GoogleLogin, GoogleOAuthProvider } from '@react-oauth/google';
 import "./style.css";
-import { FacebookLoginButton } from "react-social-login-buttons";
-import { LoginSocialFacebook } from "reactjs-social-login";
 
 import backgroundImage from "./img/movies.jpeg";
 
@@ -57,19 +56,6 @@ const Index = () => {
               />
             </GoogleOAuthProvider>
           </div>
-          <LoginSocialFacebook
-            appId="1030308514679380"
-
-            onResolve={(response) => {
-              console.log(response);
-            }}
-            onReject={(error) => {
-              console.log(error);
-            }}
-
-          >
-            <FacebookLoginButton />
-          </LoginSocialFacebook>
 
           <div style={{ textAlign: "center", color: "#FFFFFF", padding: 20 }}>
             <h3>Or</h3>

--- a/client/src/Pages/Login/index.jsx
+++ b/client/src/Pages/Login/index.jsx
@@ -1,7 +1,7 @@
 import { useState } from "react";
 import React from "react";
 import { useLogin } from "../../Hooks/useLogin.js";
-import { loginWithGoogleJWT } from "../../Hooks/useGoogleAuth.js";
+import { useGoogleAuth } from "../../Hooks/useGoogleAuth.ts";
 import { GOOGLE_CLIENT_ID } from "../../../env.js";
 import { GoogleLogin, GoogleOAuthProvider } from '@react-oauth/google';
 import "./style.css";
@@ -13,6 +13,7 @@ const Index = () => {
   const [password, setPassword] = useState("");
   const [validationError, setValidationError] = useState("");
   const { login, error, isLoading } = useLogin();
+  const { loginWithGoogleJWT, googleAuthError, googleAuthIsLoading } = useGoogleAuth();
 
   const handleSubmit = async (e) => {
     e.preventDefault();
@@ -79,6 +80,7 @@ const Index = () => {
           </button>
           {validationError && <div className="error">{validationError}</div>}
           {error && <div className="error">{error}</div>}
+          {googleAuthError && <div className="error">{googleAuthError}</div>}
         </form>
       </div>
     </div>

--- a/client/src/Pages/Login/index.jsx
+++ b/client/src/Pages/Login/index.jsx
@@ -25,9 +25,14 @@ const Index = () => {
     await login(username, password);
   };
 
-  const handleGoogleSignIn = async (credentialResponse) => {
-    console.log(credentialResponse.credential);
-    alert("Signed in with Google");
+  // Pass the Google JWT to the server to sign the user in
+  const handleGoogleSignInSuccess = async (credentialResponse) => {
+    console.log(credentialResponse);
+  };
+
+  // Display Google sign in errors to the user
+  const handleGoogleSignInError = (error) => {
+    console.log(error);
   };
 
   return (
@@ -43,24 +48,16 @@ const Index = () => {
       <div className="overlay-login"></div>
       <div className="login-page">
         <form className="login" onSubmit={handleSubmit}>
-          <h3 style={{ paddingBottom: 10 }}>Log In</h3>
-          <div style={{ padding: 5 }}>
+          <h3 className="title">Log In</h3>
+          <div className="googleAuthContainer">
             <GoogleOAuthProvider clientId={GOOGLE_CLIENT_ID}>
-              <GoogleLogin width={390}
-                onSuccess={credentialResponse => {
-                  console.log(credentialResponse);
-                }}
-                onError={() => {
-                  console.log('Login Failed');
-                }}
-              />
+              <GoogleLogin width={390} onSuccess={handleGoogleSignInSuccess} onError={handleGoogleSignInError} />
             </GoogleOAuthProvider>
           </div>
 
-          <div style={{ textAlign: "center", color: "#FFFFFF", padding: 20 }}>
+          <div className="orContainer">
             <h3>Or</h3>
           </div>
-
 
           <label>Username:</label>
           <input

--- a/client/src/Pages/Login/style.css
+++ b/client/src/Pages/Login/style.css
@@ -1,134 +1,147 @@
-label, input {
-    display: block;
+label,
+input {
+  display: block;
 }
 
 input {
-    padding: 10px;
-    margin-top: 10px;
-    margin-bottom: 20px;
-    width: 100%;
-    border: 1px solid #ddd;
-    border-radius: 4px;
-    box-sizing: border-box;
+  padding: 10px;
+  margin-top: 10px;
+  margin-bottom: 20px;
+  width: 100%;
+  border: 1px solid #ddd;
+  border-radius: 4px;
+  box-sizing: border-box;
 }
 
 /* More info button */
 .movie-details-home button,
 .login button {
-    background-color: #fff;
-    border: 1px solid #d5d9d9;
-    font-family: 'Roboto', sans-serif;
-    border-radius: 8px;
-    box-shadow: rgba(213, 217, 217, .5) 0 2px 5px 0;
-    box-sizing: border-box;
-    color: #0f1111;
-    cursor: pointer;
-    display: inline-block;
-    font-size: 16px;
-    line-height: 29px;
-    padding: 0 15px 0 11px;
-    position: relative;
-    text-align: center;
-    text-decoration: none;
-    user-select: none;
-    -webkit-user-select: none;
-    touch-action: manipulation;
-    vertical-align: middle;
-    width: 100px;
+  background-color: #fff;
+  border: 1px solid #d5d9d9;
+  font-family: "Roboto", sans-serif;
+  border-radius: 8px;
+  box-shadow: rgba(213, 217, 217, 0.5) 0 2px 5px 0;
+  box-sizing: border-box;
+  color: #0f1111;
+  cursor: pointer;
+  display: inline-block;
+  font-size: 16px;
+  line-height: 29px;
+  padding: 0 15px 0 11px;
+  position: relative;
+  text-align: center;
+  text-decoration: none;
+  user-select: none;
+  -webkit-user-select: none;
+  touch-action: manipulation;
+  vertical-align: middle;
+  width: 100px;
 }
 
 .overlay-login {
-    position: absolute;
-    top: 0;
-    left: 0;
-    width: 100%;
-    height: 100%;
-    background-color: rgba(0, 0, 0, 0.4); /* Semi-transparent black overlay */
-    z-index: 2; /* Position the overlay between the background and the content */
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  background-color: rgba(0, 0, 0, 0.4); /* Semi-transparent black overlay */
+  z-index: 2; /* Position the overlay between the background and the content */
 }
 
-.login-page{
-    z-index: 2;
-    width: 500px;
+.login-page {
+  z-index: 2;
+  width: 500px;
 }
-
 
 /* Home container */
 .home-container-login {
-    position: relative;
-    display: flex;
-    height: 800px;
-    justify-content: center;
-    align-items: center;
-    overflow: hidden;
-    background: none;
-    z-index: 1;
+  position: relative;
+  display: flex;
+  height: 800px;
+  justify-content: center;
+  align-items: center;
+  overflow: hidden;
+  background: none;
+  z-index: 1;
 }
 
 .background-image-login {
-    position: absolute;
-    top: 0;
-    left: 0;
-    width: 100%;
-    height: 100%;
-    z-index: 2; /* Position the background behind the content */
-    filter: blur(5px); /* Apply the blur effect */
-    background-size: cover;
-    background-repeat: no-repeat;
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  z-index: 2; /* Position the background behind the content */
+  filter: blur(5px); /* Apply the blur effect */
+  background-size: cover;
+  background-repeat: no-repeat;
 }
 
 .movie-details-home button:hover,
 .login button:hover {
-    background-color: #f7fafa;
+  background-color: #f7fafa;
 }
 
 .movie-details-home button:focus,
 .login button:focus {
-    border-color: #008296;
-    box-shadow: rgba(213, 217, 217, .5) 0 2px 5px 0;
-    outline: 0;
+  border-color: #008296;
+  box-shadow: rgba(213, 217, 217, 0.5) 0 2px 5px 0;
+  outline: 0;
 }
 
 .login {
-    max-width: 400px;
-    margin: 40px auto;
-    padding: 20px;
-    color: white;
-    background-color: #2a2d32;
-    border-radius: 4px;
-    color: #000; /* Set text color to black */
-    z-index: 8;
-    
+  max-width: 400px;
+  margin: 40px auto;
+  padding: 20px;
+  color: white;
+  background-color: #2a2d32;
+  border-radius: 4px;
+  color: #000; /* Set text color to black */
+  z-index: 8;
 }
 
-.login h3{
-    color: white;
+.login h3 {
+  color: white;
 }
 
-.login label{
-    color: white;
+.login label {
+  color: white;
 }
 
 form button {
-    background: #E3FFE3;
-    border: 0;
-    color: #111;
-    padding: 10px;
-    font-family: "Poppins", serif;
-    border-radius: 4px;
-    cursor: pointer;
+  background: #e3ffe3;
+  border: 0;
+  color: #111;
+  padding: 10px;
+  font-family: "Poppins", serif;
+  border-radius: 4px;
+  cursor: pointer;
 }
 
 div.error {
-    padding: 10px;
-    background: #ffefef;
-    border: 1px solid #e7195a;
-    color: #e7195a;
-    border-radius: 4px;
-    margin: 20px 0;
+  padding: 10px;
+  background: #ffefef;
+  border: 1px solid #e7195a;
+  color: #e7195a;
+  border-radius: 4px;
+  margin: 20px 0;
 }
 
 input.error {
-    border: 1px solid #e7195a;
+  border: 1px solid #e7195a;
 }
 
+/* Google Auth Styling */
+.title {
+  padding-bottom: 10px;
+}
+
+.googleAuthContainer {
+  padding: 5px 5px 5px 5px;
+}
+
+.orContainer {
+  text-align: center;
+  color: #ffffff;
+  padding: 20px 20px 20px 20px;
+}

--- a/client/src/Pages/Signup/index.jsx
+++ b/client/src/Pages/Signup/index.jsx
@@ -2,8 +2,6 @@ import { useState } from "react";
 import { useSignup } from "../../Hooks/useSignup.js";
 import "./style.css";
 import backgroundImage from "./img/movies.jpeg";
-import { FacebookLoginButton } from "react-social-login-buttons";
-import { LoginSocialFacebook } from "reactjs-social-login";
 import React from "react";
 
 const Index = () => {

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,8 +13,6 @@
         "@types/react": "^18.2.22",
         "@types/react-dom": "^18.2.7",
         "react-loader-spinner": "^5.4.5",
-        "react-social-login-buttons": "^3.9.1",
-        "reactjs-social-login": "^2.6.3",
         "typescript": "^5.2.2"
       }
     },
@@ -1190,26 +1188,6 @@
       "peerDependencies": {
         "react": "^16.0.0 || ^17.0.0 || ^18.0.0",
         "react-dom": "^16.0.0 || ^17.0.0 || ^18.0.0"
-      }
-    },
-    "node_modules/react-social-login-buttons": {
-      "version": "3.9.1",
-      "resolved": "https://registry.npmjs.org/react-social-login-buttons/-/react-social-login-buttons-3.9.1.tgz",
-      "integrity": "sha512-KtucVWvdnIZ0icG99WJ3usQUJYmlKsOIBYGyngcuNSVyyYdZtif4KHY80qnCg+teDlgYr54ToQtg3x26ZqaS2w==",
-      "peerDependencies": {
-        "react": "^15.0.0 || ^16.0.0 || ^17.x || ^18.x"
-      }
-    },
-    "node_modules/reactjs-social-login": {
-      "version": "2.6.3",
-      "resolved": "https://registry.npmjs.org/reactjs-social-login/-/reactjs-social-login-2.6.3.tgz",
-      "integrity": "sha512-i/pcyJPtlVpHoPRr/j5/KjaP/GNxAInnnHDk0PD2Zo0B3cMdvr0ZiGC/GMjOKAAgKCujyniDf/OiZ7c6MrOLQg==",
-      "engines": {
-        "node": ">=10"
-      },
-      "peerDependencies": {
-        "react": "^16 || ^17 || ^18",
-        "react-dom": "^16 || ^17 || ^18"
       }
     },
     "node_modules/scheduler": {

--- a/package.json
+++ b/package.json
@@ -14,8 +14,6 @@
     "@types/react": "^18.2.22",
     "@types/react-dom": "^18.2.7",
     "react-loader-spinner": "^5.4.5",
-    "react-social-login-buttons": "^3.9.1",
-    "reactjs-social-login": "^2.6.3",
     "typescript": "^5.2.2"
   }
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -36,7 +36,7 @@
     // "types": [],                                      /* Specify type package names to be included without being referenced in a source file. */
     // "allowUmdGlobalAccess": true,                     /* Allow accessing UMD globals from modules. */
     // "moduleSuffixes": [],                             /* List of file name suffixes to search when resolving a module. */
-    // "allowImportingTsExtensions": true,               /* Allow imports to include TypeScript file extensions. Requires '--moduleResolution bundler' and either '--noEmit' or '--emitDeclarationOnly' to be set. */
+    "allowImportingTsExtensions": true,               /* Allow imports to include TypeScript file extensions. Requires '--moduleResolution bundler' and either '--noEmit' or '--emitDeclarationOnly' to be set. */
     // "resolvePackageJsonExports": true,                /* Use the package.json 'exports' field when resolving package imports. */
     // "resolvePackageJsonImports": true,                /* Use the package.json 'imports' field when resolving imports. */
     // "customConditions": [],                           /* Conditions to set in addition to the resolver-specific defaults when resolving imports. */


### PR DESCRIPTION
This PR extends the client side login logic to add functionality to redirect users to start a Google OAuth2 flow, capture Google JWTs, handle Google authentication errors, pass Google JWTs to the server end point `/login_google` and then persist the JWT on the client side upon successful authentication on the server side. 

To finish implementing authentication with Google:
- Server side logic needs to be added for validating Google JWTs and returning an internal JWT that can be persisted by the user
- Update the UI to include a sign up with Google button on the sign up page